### PR TITLE
Add status for disabled slots

### DIFF
--- a/src/HFM.Core/Client/SlotStatus.cs
+++ b/src/HFM.Core/Client/SlotStatus.cs
@@ -46,7 +46,11 @@ namespace HFM.Core.Client
         /// <summary>
         /// The slot is offline.
         /// </summary>
-        Offline = 8
+        Offline = 8,
+        /// <summary>
+        /// The slot is disabled.
+        /// </summary>
+        Disabled = 9
     }
 
     public static class SlotStatusExtensions
@@ -73,6 +77,8 @@ namespace HFM.Core.Client
                     return Color.Orange;
                 case SlotStatus.Offline:
                     return Color.Gray;
+                case SlotStatus.Disabled:
+                    return Color.DimGray;
                 default:
                     return Color.Gray;
             }


### PR DESCRIPTION
This to add a status for disabled slots. Integrated GPU slots are now added and set to disabled by default in folding at home. This results in HFM to not display any slots on that computer.
Example with no slots displayed:
![image](https://user-images.githubusercontent.com/77532567/113882620-20877880-97c6-11eb-8f16-4ac3f5c90dfb.png)
Example with 1 disabled slot and 1 running slot:
![image](https://user-images.githubusercontent.com/77532567/113884003-511be200-97c7-11eb-8c91-702b2e1552c8.png)

