### PR TITLE
Add processor information to the slot summary web generation output (xml and html)

### DIFF
--- a/src/HFM.Core/SlotXml/SlotData.cs
+++ b/src/HFM.Core/SlotXml/SlotData.cs
@@ -28,72 +28,72 @@ namespace HFM.Core.SlotXml
         public string SlotType { get; set; }
 
         [DataMember(Order = 7)]
-        public string Processor { get; set; }
-
-        [DataMember(Order = 8)]
         public string ClientVersion { get; set; }
 
-        [DataMember(Order = 9)]
+        [DataMember(Order = 8)]
         public string TPF { get; set; }
 
-        [DataMember(Order = 10)]
+        [DataMember(Order = 9)]
         public double PPD { get; set; }
 
-        [DataMember(Order = 11)]
+        [DataMember(Order = 10)]
         public double UPD { get; set; }
 
-        [DataMember(Order = 12)]
+        [DataMember(Order = 11)]
         public string ETA { get; set; }
 
-        [DataMember(Order = 13)]
+        [DataMember(Order = 12)]
         public string Core { get; set; }
 
-        [DataMember(Order = 14)]
+        [DataMember(Order = 13)]
         public string CoreId { get; set; }
 
-        [DataMember(Order = 15)]
+        [DataMember(Order = 14)]
         public bool ProjectIsDuplicate { get; set; }
 
-        [DataMember(Order = 16)]
+        [DataMember(Order = 15)]
         public string ProjectRunCloneGen { get; set; }
 
-        [DataMember(Order = 17)]
+        [DataMember(Order = 16)]
         public double Credit { get; set; }
 
-        [DataMember(Order = 18)]
+        [DataMember(Order = 17)]
         public int Completed { get; set; }
 
-        [DataMember(Order = 19)]
+        [DataMember(Order = 18)]
         public int Failed { get; set; }
 
-        [DataMember(Order = 20)]
+        [DataMember(Order = 19)]
         public int TotalRunCompletedUnits { get; set; }
 
-        [DataMember(Order = 21)]
+        [DataMember(Order = 20)]
         public int TotalCompletedUnits { get; set; }
 
-        [DataMember(Order = 22)]
+        [DataMember(Order = 21)]
         public int TotalRunFailedUnits { get; set; }
 
-        [DataMember(Order = 23)]
+        [DataMember(Order = 22)]
         public int TotalFailedUnits { get; set; }
 
-        [DataMember(Order = 24)]
+        [DataMember(Order = 23)]
         public bool UsernameOk { get; set; }
 
-        [DataMember(Order = 25)]
+        [DataMember(Order = 24)]
         public string Username { get; set; }
 
-        [DataMember(Order = 26)]
+        [DataMember(Order = 25)]
         public string DownloadTime { get; set; }
 
-        [DataMember(Order = 27)]
+        [DataMember(Order = 26)]
         public string PreferredDeadline { get; set; }
 
-        [DataMember(Order = 28)]
+        [DataMember(Order = 27)]
         public IList<LogLine> CurrentLogLines { get; set; }
 
-        [DataMember(Order = 29)]
+        [DataMember(Order = 28)]
         public Protein Protein { get; set; }
+
+        [DataMember(Order = 29)]
+        public string Processor { get; set; }
     }
 }

--- a/src/HFM.Core/SlotXml/SlotData.cs
+++ b/src/HFM.Core/SlotXml/SlotData.cs
@@ -28,69 +28,72 @@ namespace HFM.Core.SlotXml
         public string SlotType { get; set; }
 
         [DataMember(Order = 7)]
-        public string ClientVersion { get; set; }
+        public string Processor { get; set; }
 
         [DataMember(Order = 8)]
-        public string TPF { get; set; }
+        public string ClientVersion { get; set; }
 
         [DataMember(Order = 9)]
-        public double PPD { get; set; }
+        public string TPF { get; set; }
 
         [DataMember(Order = 10)]
-        public double UPD { get; set; }
+        public double PPD { get; set; }
 
         [DataMember(Order = 11)]
-        public string ETA { get; set; }
+        public double UPD { get; set; }
 
         [DataMember(Order = 12)]
-        public string Core { get; set; }
+        public string ETA { get; set; }
 
         [DataMember(Order = 13)]
-        public string CoreId { get; set; }
+        public string Core { get; set; }
 
         [DataMember(Order = 14)]
-        public bool ProjectIsDuplicate { get; set; }
+        public string CoreId { get; set; }
 
         [DataMember(Order = 15)]
-        public string ProjectRunCloneGen { get; set; }
+        public bool ProjectIsDuplicate { get; set; }
 
         [DataMember(Order = 16)]
-        public double Credit { get; set; }
+        public string ProjectRunCloneGen { get; set; }
 
         [DataMember(Order = 17)]
-        public int Completed { get; set; }
+        public double Credit { get; set; }
 
         [DataMember(Order = 18)]
-        public int Failed { get; set; }
+        public int Completed { get; set; }
 
         [DataMember(Order = 19)]
-        public int TotalRunCompletedUnits { get; set; }
+        public int Failed { get; set; }
 
         [DataMember(Order = 20)]
-        public int TotalCompletedUnits { get; set; }
+        public int TotalRunCompletedUnits { get; set; }
 
         [DataMember(Order = 21)]
-        public int TotalRunFailedUnits { get; set; }
+        public int TotalCompletedUnits { get; set; }
 
         [DataMember(Order = 22)]
-        public int TotalFailedUnits { get; set; }
+        public int TotalRunFailedUnits { get; set; }
 
         [DataMember(Order = 23)]
-        public bool UsernameOk { get; set; }
+        public int TotalFailedUnits { get; set; }
 
         [DataMember(Order = 24)]
-        public string Username { get; set; }
+        public bool UsernameOk { get; set; }
 
         [DataMember(Order = 25)]
-        public string DownloadTime { get; set; }
+        public string Username { get; set; }
 
         [DataMember(Order = 26)]
-        public string PreferredDeadline { get; set; }
+        public string DownloadTime { get; set; }
 
         [DataMember(Order = 27)]
-        public IList<LogLine> CurrentLogLines { get; set; }
+        public string PreferredDeadline { get; set; }
 
         [DataMember(Order = 28)]
+        public IList<LogLine> CurrentLogLines { get; set; }
+
+        [DataMember(Order = 29)]
         public Protein Protein { get; set; }
     }
 }

--- a/src/HFM.Core/SlotXml/XmlBuilder.cs
+++ b/src/HFM.Core/SlotXml/XmlBuilder.cs
@@ -132,6 +132,7 @@ namespace HFM.Core.SlotXml
             slotData.PercentComplete = slot.PercentComplete;
             slotData.Name = slot.Name;
             slotData.SlotType = slot.SlotTypeString;
+            slotData.Processor = (slot as FahClientSlotModel)?.Processor;
             slotData.ClientVersion = slot.Client.ClientVersion;
             slotData.TPF = slot.TPF.ToString();
             slotData.PPD = slot.PPD;

--- a/src/HFM/XSL/WebSummary.xslt
+++ b/src/HFM/XSL/WebSummary.xslt
@@ -15,7 +15,7 @@
             <table class="Overview" width="100%">
                <tr>
                   <td class="Heading" colspan="2">Summary</td>
-                  <td class="Plain" colspan="14">
+                  <td class="Plain" colspan="15">
                      <a href="index.html">Overview Page</a>
                   </td>
                </tr>
@@ -24,6 +24,7 @@
                   <td class="Heading">Progress</td>
                   <td class="Heading">Name</td>
                   <td class="Heading">Slot Type</td>
+                  <td class="Heading">Processor</td>
                   <td class="Heading">TPF</td>
                   <td class="Heading">PPD</td>
                   <td class="Heading">ETA</td>
@@ -105,16 +106,19 @@
          <td width="6%" class="RightCol">
             <xsl:value-of select="SlotType"/>
          </td>
+         <td width="5%" class="RightCol">
+            <xsl:value-of select="Processor"/>
+         </td>
          <td width="4%" class="RightCol">
             <xsl:value-of select="TPF"/>
          </td>
          <td width="8%" class="RightCol">
             <xsl:value-of select="format-number(PPD, $NumberFormat)"/> (<xsl:value-of select="format-number(UPD, $NumberFormat)"/> WUs)
          </td>
-         <td width="7%" class="RightCol">
+         <td width="4%" class="RightCol">
             <xsl:value-of select="ETA"/>
          </td>
-         <td width="8%" class="RightCol">
+         <td width="4%" class="RightCol">
             <xsl:value-of select="Core"/>
          </td>
          <td width="2%" class="RightCol">
@@ -153,10 +157,10 @@
             </xsl:choose>
             <xsl:value-of select="Username"/>
          </td>
-         <td width="8%" class="RightCol">
+         <td width="9%" class="RightCol">
             <xsl:value-of select="DownloadTime"/>
          </td>
-         <td width="8%" class="RightCol"> <!--100%-->
+         <td width="9%" class="RightCol"> <!--100%-->
             <xsl:value-of select="PreferredDeadline"/>
          </td>
       </tr>


### PR DESCRIPTION
This adds a new column to the web generation of the slot summary for both xml and html.  The new column will display the processor (or GPU).

An example of the generated summary.html with the new column:
![image](https://user-images.githubusercontent.com/4018878/122853810-ca17d980-d2e0-11eb-9395-b72ab7240301.png)
