### PR TITLE
Limit the number of log lines included in the web generation files.

### DIFF
--- a/src/HFM.Core/SlotXml/XmlBuilder.cs
+++ b/src/HFM.Core/SlotXml/XmlBuilder.cs
@@ -125,6 +125,9 @@ namespace HFM.Core.SlotXml
 
         internal SlotData CreateSlotData(SlotModel slot)
         {
+            // to prevent large xml files, limit the number of log lines
+            var maxLogLines = 500;
+
             var slotData = new SlotData();
             slotData.Status = slot.Status;
             slotData.StatusColor = ColorTranslator.ToHtml(slot.Status.GetStatusColor());
@@ -155,7 +158,7 @@ namespace HFM.Core.SlotXml
             slotData.Username = slot.Username;
             slotData.DownloadTime = slot.Assigned.ToShortStringOrEmpty();
             slotData.PreferredDeadline = slot.PreferredDeadline.ToShortStringOrEmpty();
-            slotData.CurrentLogLines = slot.CurrentLogLines.Select(x => _mapper.Map<Log.LogLine, LogLine>(x)).ToList();
+            slotData.CurrentLogLines = slot.CurrentLogLines.Skip(slot.CurrentLogLines.Count - maxLogLines).Select(x => _mapper.Map<Log.LogLine, LogLine>(x)).ToList();
             slotData.Protein = _mapper.Map<Proteins.Protein, Protein>(slot.WorkUnitModel.CurrentProtein);
             return slotData;
         }


### PR DESCRIPTION
This will limit the number of log lines included in the web generation output to 500 lines.

Closes #349 