### PR TITLE
Fix #358 High DPI scaling row height

### DIFF
--- a/src/HFM.Forms/Views/MainForm.cs
+++ b/src/HFM.Forms/Views/MainForm.cs
@@ -611,6 +611,7 @@ namespace HFM.Forms.Views
         private void SetupDataGridView()
         {
             dataGridView1.AutoGenerateColumns = false;
+            dataGridView1.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.DisplayedCellsExceptHeaders;
             SetupDataGridViewColumns(dataGridView1);
 
             _columnSelector = new DataGridViewColumnSelector(dataGridView1);

--- a/src/HFM.Forms/Views/WorkUnitHistoryForm.cs
+++ b/src/HFM.Forms/Views/WorkUnitHistoryForm.cs
@@ -190,6 +190,7 @@ namespace HFM.Forms.Views
             string numberFormat = NumberFormat.Get(preferences.Get<int>(Preference.DecimalPlaces));
 
             dgv.AutoGenerateColumns = false;
+            dgv.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.DisplayedCellsExceptHeaders;
             AddColumn(WorkUnitRowColumn.ProjectID, names);
             AddColumn(WorkUnitRowColumn.SlotName, names);
             AddColumn(WorkUnitRowColumn.ConnectionString, names);

--- a/src/HFM.Forms/Views/WorkUnitQueryDialog.cs
+++ b/src/HFM.Forms/Views/WorkUnitQueryDialog.cs
@@ -46,6 +46,7 @@ namespace HFM.Forms.Views
         private void SetupDataGridViewColumns()
         {
             dataGridView1.AutoGenerateColumns = false;
+            dataGridView1.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.DisplayedCellsExceptHeaders;
 
             var queryColumn = new DataGridViewComboBoxColumn();
             var columnChoices = GetQueryFieldChoices();


### PR DESCRIPTION
This fixes reported issue #358 in three places by setting the data grid row auto sizing mode to `DisplayedCellsExceptHeaders`.
Using that specific setting for performance reasons (using `AllCellsExceptHeaders` is a big performance hit when displaying the `WorkUnitHistoryForm` when there are lots of rows).
* `MainForm.cs` - fixes the main display of slots
* `WorkUnitHistoryForm.cs` - fixes the display of history rows
* `WorkUnitQueryDialog.cs` - fixes the filter option rows

NOTE: I have fixed these 3 places based on doing a quick search for where `AutoGenerateColumns` property was being set in the code base.  There may be other datagrids which need fixing that do not set this flag so I didn't see/look for them.

TESTING: I viewed these data grids on a 4K monitor with 150% text scaling in Windows 10.  I did not test on any other resolutions, font scaling levels, or OS.